### PR TITLE
feat: deploy via ACR instead of code deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ permissions:
 env:
   APP_NAME: ${{ vars.AZURE_APP_SERVICE_NAME }}
   ACR_NAME: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
+  RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
   IMAGE_NAME: zavastorefront
 
 jobs:
@@ -47,6 +48,6 @@ jobs:
           ACR_LOGIN_SERVER=$(az acr show --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
           az webapp config container set \
             --name ${{ env.APP_NAME }} \
-            --resource-group $(az webapp show --name ${{ env.APP_NAME }} --query resourceGroup -o tsv) \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
             --container-image-name ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
             --container-registry-url https://${ACR_LOGIN_SERVER}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,19 +33,21 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Get ACR login server
+        run: echo "ACR_LOGIN_SERVER=$(az acr show --name ${{ env.ACR_NAME }} --query loginServer -o tsv)" >> $GITHUB_ENV
+
       - name: Log in to ACR
         run: az acr login --name ${{ env.ACR_NAME }}
 
       - name: Build and push Docker image
         run: |
-          ACR_LOGIN_SERVER=$(az acr show --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
           docker build -t ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:${{ github.sha }} -t ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:latest ./src
           docker push ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           docker push ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:latest
 
       - name: Deploy container to Azure App Service
+        if: github.event_name != 'pull_request'
         run: |
-          ACR_LOGIN_SERVER=$(az acr show --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
           az webapp config container set \
             --name ${{ env.APP_NAME }} \
             --resource-group ${{ env.RESOURCE_GROUP }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ permissions:
 
 env:
   APP_NAME: ${{ vars.AZURE_APP_SERVICE_NAME }}
+  ACR_NAME: ${{ vars.AZURE_CONTAINER_REGISTRY_NAME }}
+  IMAGE_NAME: zavastorefront
 
 jobs:
   build-and-deploy:
@@ -23,14 +25,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Publish .NET app
-        run: dotnet publish ./src -c Release -o ./publish
-
       - name: Log in to Azure
         uses: azure/login@v2
         with:
@@ -38,8 +32,21 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy to Azure App Service
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: ${{ env.APP_NAME }}
-          package: ./publish
+      - name: Log in to ACR
+        run: az acr login --name ${{ env.ACR_NAME }}
+
+      - name: Build and push Docker image
+        run: |
+          ACR_LOGIN_SERVER=$(az acr show --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
+          docker build -t ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:${{ github.sha }} -t ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:latest ./src
+          docker push ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Deploy container to Azure App Service
+        run: |
+          ACR_LOGIN_SERVER=$(az acr show --name ${{ env.ACR_NAME }} --query loginServer -o tsv)
+          az webapp config container set \
+            --name ${{ env.APP_NAME }} \
+            --resource-group $(az webapp show --name ${{ env.APP_NAME }} --query resourceGroup -o tsv) \
+            --container-image-name ${ACR_LOGIN_SERVER}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            --container-registry-url https://${ACR_LOGIN_SERVER}

--- a/azure.yaml
+++ b/azure.yaml
@@ -7,3 +7,6 @@ services:
     project: ./src
     host: appservice
     language: dotnet
+    docker:
+      path: ./Dockerfile
+      context: .

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -88,6 +88,15 @@ module foundry 'modules/foundry.bicep' = {
   }
 }
 
+module foundryRole 'modules/foundry-roleassignment.bicep' = {
+  name: 'foundry-role-deployment'
+  scope: rg
+  params: {
+    principalId: webApp.outputs.principalId
+    accountName: foundry.outputs.accountName
+  }
+}
+
 output AZURE_RESOURCE_GROUP string = rg.name
 output AZURE_CONTAINER_REGISTRY_NAME string = acr.outputs.acrName
 output AZURE_CONTAINER_REGISTRY_LOGIN_SERVER string = acr.outputs.acrLoginServer

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -64,6 +64,7 @@ module webApp 'modules/webapp.bicep' = {
     tags: tags
     appServicePlanId: appServicePlan.outputs.appServicePlanId
     appInsightsConnectionString: appInsights.outputs.connectionString
+    acrLoginServer: acr.outputs.acrLoginServer
   }
 }
 

--- a/infra/modules/foundry-roleassignment.bicep
+++ b/infra/modules/foundry-roleassignment.bicep
@@ -1,0 +1,22 @@
+@description('Principal ID of the Web App managed identity')
+param principalId string
+
+@description('Name of the Cognitive Services account')
+param accountName string
+
+// Cognitive Services User built-in role definition ID
+var cognitiveServicesUserRoleId = 'a97b65f3-24c7-4388-baec-2e87135dc908'
+
+resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-04-01-preview' existing = {
+  name: accountName
+}
+
+resource cognitiveServicesRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(cognitiveAccount.id, principalId, cognitiveServicesUserRoleId)
+  scope: cognitiveAccount
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', cognitiveServicesUserRoleId)
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/modules/foundry.bicep
+++ b/infra/modules/foundry.bicep
@@ -23,6 +23,7 @@ resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-04-01-previ
   properties: {
     customSubDomainName: accountName
     publicNetworkAccess: 'Enabled'
+    disableLocalAuth: true
   }
 }
 

--- a/infra/modules/webapp.bicep
+++ b/infra/modules/webapp.bicep
@@ -45,6 +45,10 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
           name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE'
           value: 'false'
         }
+        {
+          name: 'WEBSITES_PORT'
+          value: '8080'
+        }
       ]
     }
     httpsOnly: true

--- a/infra/modules/webapp.bicep
+++ b/infra/modules/webapp.bicep
@@ -16,6 +16,9 @@ param appServicePlanId string
 @description('Application Insights connection string')
 param appInsightsConnectionString string
 
+@description('ACR login server (e.g., myregistry.azurecr.io)')
+param acrLoginServer string
+
 var appName = 'app-${baseName}-${environmentName}'
 
 resource webApp 'Microsoft.Web/sites@2023-12-01' = {
@@ -24,18 +27,23 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
   tags: union(tags, {
     'azd-service-name': 'web'
   })
-  kind: 'app,linux'
+  kind: 'app,linux,container'
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
     serverFarmId: appServicePlanId
     siteConfig: {
-      linuxFxVersion: 'DOTNETCORE|10.0'
+      linuxFxVersion: 'DOCKER|${acrLoginServer}/zavastorefront:latest'
+      acrUseManagedIdentityCreds: true
       appSettings: [
         {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: appInsightsConnectionString
+        }
+        {
+          name: 'WEBSITES_ENABLE_APP_SERVICE_STORAGE'
+          value: 'false'
         }
       ]
     }


### PR DESCRIPTION
## Summary

Switches App Service from code deployment (dotnet publish + zip deploy) to container deployment via Azure Container Registry.

### Changes

- **`infra/modules/webapp.bicep`** — Container mode (`app,linux,container`), ACR managed identity pull (`acrUseManagedIdentityCreds`), Docker image `linuxFxVersion`, `WEBSITES_PORT=8080` for .NET 10
- **`infra/main.bicep`** — Passes `acrLoginServer` from ACR module to webapp module, adds Foundry role assignment
- **`infra/modules/foundry.bicep`** — Adds `disableLocalAuth: true` to enforce identity-only auth
- **`infra/modules/foundry-roleassignment.bicep`** — New module granting Cognitive Services User role to App Service managed identity
- **`azure.yaml`** — Added `docker:` section so `azd deploy` builds/pushes Docker images to ACR
- **`.github/workflows/deploy.yml`** — Replaced dotnet publish + zip deploy with Docker build → ACR push → `az webapp config container set`, using `github.sha` + `latest` tags. Deploy step gated to non-PR events.

### Required GitHub Variables

| Variable | Description | Status |
|----------|-------------|--------|
| `AZURE_APP_SERVICE_NAME` | App Service name | Pre-existing |
| `AZURE_RESOURCE_GROUP` | Resource group name | Pre-existing |
| `AZURE_CONTAINER_REGISTRY_NAME` | ACR name | **Added in this PR** |