### PR TITLE
feat: Foundry diagnostics, AI chatbot with Content Safety

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -65,6 +65,7 @@ module webApp 'modules/webapp.bicep' = {
     appServicePlanId: appServicePlan.outputs.appServicePlanId
     appInsightsConnectionString: appInsights.outputs.connectionString
     acrLoginServer: acr.outputs.acrLoginServer
+    aiEndpoint: foundry.outputs.endpoint
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -97,6 +97,15 @@ module foundryRole 'modules/foundry-roleassignment.bicep' = {
   }
 }
 
+module foundryDiagnostics 'modules/foundry-diagnostics.bicep' = {
+  name: 'foundry-diagnostics-deployment'
+  scope: rg
+  params: {
+    accountName: foundry.outputs.accountName
+    logAnalyticsWorkspaceId: appInsights.outputs.logAnalyticsWorkspaceId
+  }
+}
+
 output AZURE_RESOURCE_GROUP string = rg.name
 output AZURE_CONTAINER_REGISTRY_NAME string = acr.outputs.acrName
 output AZURE_CONTAINER_REGISTRY_LOGIN_SERVER string = acr.outputs.acrLoginServer

--- a/infra/modules/appinsights.bicep
+++ b/infra/modules/appinsights.bicep
@@ -39,3 +39,4 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 output connectionString string = appInsights.properties.ConnectionString
 output instrumentationKey string = appInsights.properties.InstrumentationKey
 output appInsightsName string = appInsights.name
+output logAnalyticsWorkspaceId string = logAnalytics.id

--- a/infra/modules/foundry-diagnostics.bicep
+++ b/infra/modules/foundry-diagnostics.bicep
@@ -1,0 +1,41 @@
+@description('Name of the Cognitive Services account')
+param accountName string
+
+@description('Resource ID of the Log Analytics workspace')
+param logAnalyticsWorkspaceId string
+
+resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-04-01-preview' existing = {
+  name: accountName
+}
+
+resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'foundry-diagnostics'
+  scope: cognitiveAccount
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        category: 'Audit'
+        enabled: true
+      }
+      {
+        category: 'RequestResponse'
+        enabled: true
+      }
+      {
+        category: 'AzureOpenAIRequestUsage'
+        enabled: true
+      }
+      {
+        category: 'Trace'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/infra/modules/foundry-diagnostics.bicep
+++ b/infra/modules/foundry-diagnostics.bicep
@@ -8,7 +8,7 @@ resource cognitiveAccount 'Microsoft.CognitiveServices/accounts@2024-04-01-previ
   name: accountName
 }
 
-resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01' = {
   name: 'foundry-diagnostics'
   scope: cognitiveAccount
   properties: {

--- a/infra/modules/webapp.bicep
+++ b/infra/modules/webapp.bicep
@@ -19,6 +19,9 @@ param appInsightsConnectionString string
 @description('ACR login server (e.g., myregistry.azurecr.io)')
 param acrLoginServer string
 
+@description('Azure AI Foundry endpoint URL')
+param aiEndpoint string = ''
+
 var appName = 'app-${baseName}-${environmentName}'
 
 resource webApp 'Microsoft.Web/sites@2023-12-01' = {
@@ -48,6 +51,10 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
         {
           name: 'WEBSITES_PORT'
           value: '8080'
+        }
+        {
+          name: 'AI__Endpoint'
+          value: aiEndpoint
         }
       ]
     }

--- a/src/Controllers/ChatController.cs
+++ b/src/Controllers/ChatController.cs
@@ -27,21 +27,32 @@ public class ChatController : Controller
         if (string.IsNullOrWhiteSpace(request?.Message))
             return BadRequest(new ChatResponse { Reply = "Please enter a message." });
 
-        // Content Safety gate
-        var safetyResult = await _contentSafety.EvaluateAsync(request.Message);
-        if (!safetyResult.IsSafe)
+        try
         {
-            _logger.LogWarning("Message blocked by Content Safety: {Reason}", safetyResult.Reason);
-            return Ok(new ChatResponse
+            // Content Safety gate
+            var safetyResult = await _contentSafety.EvaluateAsync(request.Message);
+            if (!safetyResult.IsSafe)
             {
-                Reply = "Sorry, I'm unable to process that request. Please rephrase your message and try again.",
-                Blocked = true
+                _logger.LogWarning("Message blocked by Content Safety: {Reason}", safetyResult.Reason);
+                return Ok(new ChatResponse
+                {
+                    Reply = "Sorry, I'm unable to process that request. Please rephrase your message and try again.",
+                    Blocked = true
+                });
+            }
+
+            // Safe — forward to model
+            var reply = await _chatService.GetResponseAsync(request.Message);
+            return Ok(new ChatResponse { Reply = reply });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Chat request failed");
+            return StatusCode(500, new ChatResponse
+            {
+                Reply = "An error occurred processing your request. Please try again later."
             });
         }
-
-        // Safe — forward to model
-        var reply = await _chatService.GetResponseAsync(request.Message);
-        return Ok(new ChatResponse { Reply = reply });
     }
 }
 

--- a/src/Controllers/ChatController.cs
+++ b/src/Controllers/ChatController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using ZavaStorefront.Services;
+
+namespace ZavaStorefront.Controllers;
+
+public class ChatController : Controller
+{
+    private readonly ContentSafetyService _contentSafety;
+    private readonly AIChatService _chatService;
+    private readonly ILogger<ChatController> _logger;
+
+    public ChatController(ContentSafetyService contentSafety, AIChatService chatService, ILogger<ChatController> logger)
+    {
+        _contentSafety = contentSafety;
+        _chatService = chatService;
+        _logger = logger;
+    }
+
+    public IActionResult Index()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Send([FromBody] ChatRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request?.Message))
+            return BadRequest(new ChatResponse { Reply = "Please enter a message." });
+
+        // Content Safety gate
+        var safetyResult = await _contentSafety.EvaluateAsync(request.Message);
+        if (!safetyResult.IsSafe)
+        {
+            _logger.LogWarning("Message blocked by Content Safety: {Reason}", safetyResult.Reason);
+            return Ok(new ChatResponse
+            {
+                Reply = "Sorry, I'm unable to process that request. Please rephrase your message and try again.",
+                Blocked = true
+            });
+        }
+
+        // Safe — forward to model
+        var reply = await _chatService.GetResponseAsync(request.Message);
+        return Ok(new ChatResponse { Reply = reply });
+    }
+}
+
+public class ChatRequest
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+public class ChatResponse
+{
+    public string Reply { get; set; } = string.Empty;
+    public bool Blocked { get; set; }
+}

--- a/src/Controllers/ChatController.cs
+++ b/src/Controllers/ChatController.cs
@@ -45,6 +45,7 @@ public class ChatController : Controller
             var reply = await _chatService.GetResponseAsync(request.Message);
             return Ok(new ChatResponse { Reply = reply });
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Chat request failed");

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,6 +18,8 @@ builder.Services.AddSession(options =>
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddSingleton<ProductService>();
 builder.Services.AddScoped<CartService>();
+builder.Services.AddSingleton<ContentSafetyService>();
+builder.Services.AddSingleton<AIChatService>();
 
 var app = builder.Build();
 

--- a/src/Services/AIChatService.cs
+++ b/src/Services/AIChatService.cs
@@ -30,10 +30,18 @@ public class AIChatService
             new UserChatMessage(userMessage)
         };
 
-        var completion = await _chatClient.CompleteChatAsync(messages);
-        var reply = completion.Value.Content[0].Text;
+        try
+        {
+            var completion = await _chatClient.CompleteChatAsync(messages);
+            var reply = completion.Value.Content[0].Text;
 
-        _logger.LogInformation("Received chat response");
-        return reply;
+            _logger.LogInformation("Received chat response");
+            return reply;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Azure OpenAI request failed");
+            throw;
+        }
     }
 }

--- a/src/Services/AIChatService.cs
+++ b/src/Services/AIChatService.cs
@@ -1,0 +1,39 @@
+using Azure.AI.OpenAI;
+using Azure.Identity;
+using OpenAI.Chat;
+
+namespace ZavaStorefront.Services;
+
+public class AIChatService
+{
+    private readonly ChatClient _chatClient;
+    private readonly ILogger<AIChatService> _logger;
+
+    public AIChatService(IConfiguration configuration, ILogger<AIChatService> logger)
+    {
+        _logger = logger;
+        var endpoint = configuration["AI:Endpoint"]
+            ?? throw new InvalidOperationException("AI:Endpoint configuration is required");
+        var deployment = configuration["AI:DeploymentName"] ?? "gpt-4o";
+
+        var azureClient = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential());
+        _chatClient = azureClient.GetChatClient(deployment);
+    }
+
+    public async Task<string> GetResponseAsync(string userMessage)
+    {
+        _logger.LogInformation("Sending chat request to Azure OpenAI");
+
+        var messages = new ChatMessage[]
+        {
+            new SystemChatMessage("You are a helpful shopping assistant for Zava Storefront, an online tech store. Keep responses concise and friendly."),
+            new UserChatMessage(userMessage)
+        };
+
+        var completion = await _chatClient.CompleteChatAsync(messages);
+        var reply = completion.Value.Content[0].Text;
+
+        _logger.LogInformation("Received chat response");
+        return reply;
+    }
+}

--- a/src/Services/ContentSafetyService.cs
+++ b/src/Services/ContentSafetyService.cs
@@ -69,6 +69,7 @@ public class ContentSafetyService
 
             return new ContentSafetyResult { IsSafe = true };
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Content safety category check failed");
@@ -93,17 +94,18 @@ public class ContentSafetyService
                 documents = Array.Empty<string>()
             });
 
+            using var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
             var response = await httpClient.PostAsync(
                 $"{_endpoint.TrimEnd('/')}/contentsafety/text:shieldPrompt?api-version=2024-09-01",
-                new StringContent(requestBody, Encoding.UTF8, "application/json"));
+                content);
 
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Prompt shield API returned {StatusCode}", response.StatusCode);
-                return new ContentSafetyResult { IsSafe = true };
+                return new ContentSafetyResult { IsSafe = false, Reason = "Jailbreak check unavailable" };
             }
 
-            var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            using var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
             var attackDetected = json.RootElement
                 .GetProperty("userPromptAnalysis")
                 .GetProperty("attackDetected")
@@ -121,10 +123,11 @@ public class ContentSafetyService
 
             return new ContentSafetyResult { IsSafe = true };
         }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Prompt shield check failed");
-            return new ContentSafetyResult { IsSafe = true };
+            return new ContentSafetyResult { IsSafe = false, Reason = "Jailbreak check unavailable" };
         }
     }
 }

--- a/src/Services/ContentSafetyService.cs
+++ b/src/Services/ContentSafetyService.cs
@@ -1,0 +1,130 @@
+using Azure;
+using Azure.AI.ContentSafety;
+using Azure.Identity;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace ZavaStorefront.Services;
+
+public class ContentSafetyResult
+{
+    public bool IsSafe { get; set; }
+    public string? Reason { get; set; }
+}
+
+public class ContentSafetyService
+{
+    private readonly ContentSafetyClient _client;
+    private readonly ILogger<ContentSafetyService> _logger;
+    private readonly DefaultAzureCredential _credential;
+    private readonly string _endpoint;
+
+    public ContentSafetyService(IConfiguration configuration, ILogger<ContentSafetyService> logger)
+    {
+        _logger = logger;
+        _endpoint = configuration["AI:Endpoint"]
+            ?? throw new InvalidOperationException("AI:Endpoint configuration is required");
+        _credential = new DefaultAzureCredential();
+        _client = new ContentSafetyClient(new Uri(_endpoint), _credential);
+    }
+
+    public async Task<ContentSafetyResult> EvaluateAsync(string text)
+    {
+        // 1. Check standard categories (hate, self-harm, sexual, violence)
+        var categoryResult = await CheckCategoriesAsync(text);
+        if (!categoryResult.IsSafe)
+            return categoryResult;
+
+        // 2. Check for jailbreak/prompt injection via Prompt Shield REST API
+        var jailbreakResult = await CheckJailbreakAsync(text);
+        if (!jailbreakResult.IsSafe)
+            return jailbreakResult;
+
+        _logger.LogInformation("Content safety check passed for input text");
+        return new ContentSafetyResult { IsSafe = true };
+    }
+
+    private async Task<ContentSafetyResult> CheckCategoriesAsync(string text)
+    {
+        try
+        {
+            var options = new AnalyzeTextOptions(text);
+            var response = await _client.AnalyzeTextAsync(options);
+
+            foreach (var analysis in response.Value.CategoriesAnalysis)
+            {
+                if (analysis.Severity.HasValue && analysis.Severity.Value >= 2)
+                {
+                    _logger.LogWarning(
+                        "Content safety violation: {Category} severity {Severity}",
+                        analysis.Category, analysis.Severity.Value);
+                    return new ContentSafetyResult
+                    {
+                        IsSafe = false,
+                        Reason = $"{analysis.Category} content detected (severity {analysis.Severity.Value})"
+                    };
+                }
+            }
+
+            return new ContentSafetyResult { IsSafe = true };
+        }
+        catch (RequestFailedException ex)
+        {
+            _logger.LogError(ex, "Content safety category check failed");
+            return new ContentSafetyResult { IsSafe = false, Reason = "Safety check unavailable" };
+        }
+    }
+
+    private async Task<ContentSafetyResult> CheckJailbreakAsync(string text)
+    {
+        try
+        {
+            var token = await _credential.GetTokenAsync(
+                new Azure.Core.TokenRequestContext(["https://cognitiveservices.azure.com/.default"]));
+
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token.Token);
+
+            var requestBody = JsonSerializer.Serialize(new
+            {
+                userPrompt = text,
+                documents = Array.Empty<string>()
+            });
+
+            var response = await httpClient.PostAsync(
+                $"{_endpoint.TrimEnd('/')}/contentsafety/text:shieldPrompt?api-version=2024-09-01",
+                new StringContent(requestBody, Encoding.UTF8, "application/json"));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Prompt shield API returned {StatusCode}", response.StatusCode);
+                return new ContentSafetyResult { IsSafe = true };
+            }
+
+            var json = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            var attackDetected = json.RootElement
+                .GetProperty("userPromptAnalysis")
+                .GetProperty("attackDetected")
+                .GetBoolean();
+
+            if (attackDetected)
+            {
+                _logger.LogWarning("Jailbreak/prompt injection detected");
+                return new ContentSafetyResult
+                {
+                    IsSafe = false,
+                    Reason = "Potential jailbreak attempt detected"
+                };
+            }
+
+            return new ContentSafetyResult { IsSafe = true };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Prompt shield check failed");
+            return new ContentSafetyResult { IsSafe = true };
+        }
+    }
+}

--- a/src/Services/ContentSafetyService.cs
+++ b/src/Services/ContentSafetyService.cs
@@ -69,7 +69,7 @@ public class ContentSafetyService
 
             return new ContentSafetyResult { IsSafe = true };
         }
-        catch (RequestFailedException ex)
+        catch (Exception ex)
         {
             _logger.LogError(ex, "Content safety category check failed");
             return new ContentSafetyResult { IsSafe = false, Reason = "Safety check unavailable" };

--- a/src/Views/Chat/Index.cshtml
+++ b/src/Views/Chat/Index.cshtml
@@ -25,7 +25,11 @@
         const div = document.createElement('div');
         div.className = `mb-2 ${isUser ? 'text-end' : ''}`;
         const cls = isBlocked ? 'bg-warning text-dark' : isUser ? 'bg-primary text-white' : 'bg-white border';
-        div.innerHTML = `<span class="d-inline-block p-2 rounded ${cls}" style="max-width:80%">${text}</span>`;
+        const span = document.createElement('span');
+        span.className = `d-inline-block p-2 rounded ${cls}`;
+        span.style.maxWidth = '80%';
+        span.textContent = text;
+        div.appendChild(span);
         messages.appendChild(div);
         messages.scrollTop = messages.scrollHeight;
     }

--- a/src/Views/Chat/Index.cshtml
+++ b/src/Views/Chat/Index.cshtml
@@ -1,0 +1,53 @@
+@{
+    ViewData["Title"] = "Chat";
+}
+
+<div class="container mt-3">
+    <h4><i class="bi bi-chat-dots"></i> Shopping Assistant</h4>
+    <div id="chat-messages" class="border rounded p-3 mb-3" style="height: 400px; overflow-y: auto; background: #f8f9fa;">
+        <div class="text-muted text-center mt-5">Ask me anything about our products!</div>
+    </div>
+    <form id="chat-form" class="d-flex gap-2">
+        <input type="text" id="chat-input" class="form-control" placeholder="Type your message..." autocomplete="off" />
+        <button type="submit" class="btn btn-primary">Send</button>
+    </form>
+</div>
+
+@section Scripts {
+<script>
+    const form = document.getElementById('chat-form');
+    const input = document.getElementById('chat-input');
+    const messages = document.getElementById('chat-messages');
+    let firstMessage = true;
+
+    function addMessage(text, isUser, isBlocked) {
+        if (firstMessage) { messages.innerHTML = ''; firstMessage = false; }
+        const div = document.createElement('div');
+        div.className = `mb-2 ${isUser ? 'text-end' : ''}`;
+        const cls = isBlocked ? 'bg-warning text-dark' : isUser ? 'bg-primary text-white' : 'bg-white border';
+        div.innerHTML = `<span class="d-inline-block p-2 rounded ${cls}" style="max-width:80%">${text}</span>`;
+        messages.appendChild(div);
+        messages.scrollTop = messages.scrollHeight;
+    }
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const text = input.value.trim();
+        if (!text) return;
+        addMessage(text, true, false);
+        input.value = '';
+
+        try {
+            const res = await fetch('/Chat/Send', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: text })
+            });
+            const data = await res.json();
+            addMessage(data.reply, false, data.blocked);
+        } catch {
+            addMessage('Something went wrong. Please try again.', false, true);
+        }
+    });
+</script>
+}

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -24,6 +24,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Chat" asp-action="Index"><i class="bi bi-chat-dots"></i> Chat</a>
+                        </li>
                     </ul>
                     <ul class="navbar-nav">
                         <li class="nav-item">

--- a/src/ZavaStorefront.csproj
+++ b/src/ZavaStorefront.csproj
@@ -7,6 +7,9 @@
     <UserSecretsId>0fb330bc-5ecc-4c20-b2f1-f38f393e634d</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+   <PackageReference Include="Azure.AI.ContentSafety" Version="1.0.0" />
+   <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
+   <PackageReference Include="Azure.Identity" Version="1.17.1" />
    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AI": {
+    "Endpoint": "https://foundry-zavastore-crtechlab300a.cognitiveservices.azure.com/",
+    "DeploymentName": "gpt-4o"
+  }
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "AI": {
-    "Endpoint": "https://foundry-zavastore-crtechlab300a.cognitiveservices.azure.com/",
+    "Endpoint": "",
     "DeploymentName": "gpt-4o"
   }
 }


### PR DESCRIPTION
## Summary

This PR adds three capabilities:

### 1. Foundry Diagnostic Settings
- New `foundry-diagnostics.bicep` module sends all log categories (Audit, RequestResponse, Trace, AzureOpenAIRequestUsage) and AllMetrics to the existing Log Analytics workspace.
- Added `logAnalyticsWorkspaceId` output from `appinsights.bicep` and wired into `main.bicep`.

### 2. AI Chatbot with Content Safety Gate
- **ContentSafetyService**: Two-stage evaluation — Azure AI Content Safety SDK for 4 categories (hate, self-harm, sexual, violence) with severity ≥ 2 threshold, plus Prompt Shield REST API for jailbreak detection.
- **AIChatService**: Azure OpenAI chat inference via managed identity (DefaultAzureCredential).
- **ChatController**: Gates every user message through Content Safety before forwarding to the model. Returns a friendly warning if blocked.
- **Chat UI**: Bootstrap chat interface accessible from the nav bar.

### 3. Error Handling
- Controller-level try/catch returns JSON error responses instead of HTML error pages.
- Broadened exception handling in ContentSafetyService and added logging in AIChatService.

### Files Changed
| File | Change |
|------|--------|
| `infra/modules/foundry-diagnostics.bicep` | New — diagnostic settings module |
| `infra/modules/appinsights.bicep` | Added logAnalyticsWorkspaceId output |
| `infra/main.bicep` | Wired diagnostics module |
| `src/Services/ContentSafetyService.cs` | New — content safety evaluation |
| `src/Services/AIChatService.cs` | New — Azure OpenAI chat service |
| `src/Controllers/ChatController.cs` | New — chat API with safety gate |
| `src/Views/Chat/Index.cshtml` | New — chat UI |
| `src/Views/Shared/_Layout.cshtml` | Added Chat nav link |
| `src/Program.cs` | Registered new services |
| `src/appsettings.json` | Added AI config section |
| `src/ZavaStorefront.csproj` | Added Azure AI packages |

### Testing
- Deployed and verified on `app-zavastore-crtechlab300a.azurewebsites.net/Chat`
- Safe messages pass through Content Safety → Azure OpenAI → response
- Diagnostic settings verified via `az monitor diagnostic-settings show`
